### PR TITLE
Added new SVComp error function name to AssertionFailCheck

### DIFF
--- a/src/LLVM/Instrumentation/DefaultChecks.cpp
+++ b/src/LLVM/Instrumentation/DefaultChecks.cpp
@@ -44,7 +44,8 @@ bool isCallToErrorFunction(llvm::Instruction& inst) {
 
     return name == "__VERIFIER_error"
         || name == "__assert_fail"
-        || name == "__gazer_error";
+        || name == "__gazer_error"
+        || name == "reach_error";
 }
 
 /// This check ensures that no assertion failure instructions are reachable.


### PR DESCRIPTION
The name of the error function in SVComp tasks was changed from __VERIFIER_error to reach_error this year ( for example [here](https://github.com/sosy-lab/sv-benchmarks/blob/master/c/locks/test_locks_14-2.c) ), so I added reach_error to Gazer's default unreachability checks.

I added an include as well. Without including limits in ADT/EnumSet.h I got a build error, but I don't know, why hasn't this been an issue for others.