### PR TITLE
Fix bad regex usage

### DIFF
--- a/src/LLVM/Instrumentation/DefaultChecks.cpp
+++ b/src/LLVM/Instrumentation/DefaultChecks.cpp
@@ -160,7 +160,7 @@ public:
 /// Checks for over- and underflow in signed integer operations.
 class SignedIntegerOverflowCheck : public Check
 {
-    static constexpr char IntrinsicPattern[] = "^llvm.(u|s)(add|sub|mul).with.overflow.i([0-9]+)$";
+    static constexpr char IntrinsicPattern[] = "^llvm\\.(u|s)(add|sub|mul)\\.with\\.overflow\\.i([0-9]+)$";
 public:
     static char ID;
 


### PR DESCRIPTION
dot (.) is a special character for regex. Use `\\.` instead for explicit dot character.

Problem arises with a function called `llvmxuaddxwithxoverflowxi1`. (where it should match only `llvm.uadd.with.overflow.i1`)