### PR TITLE
Enabled .i files and added warning for them

### DIFF
--- a/src/LLVM/ClangFrontend.cpp
+++ b/src/LLVM/ClangFrontend.cpp
@@ -183,11 +183,9 @@ auto gazer::ClangCompileAndLink(
             continue;
         }
         
-        if (inputFile.endswith_lower(".i")) {
-            emit_warning("support for preprocessed .i files is an experimental feature only");
-        } else if (!inputFile.endswith_lower(".c")) {
+        if (!inputFile.endswith_lower(".c") && !inputFile.endswith_lower(".i")) {
             llvm::errs() << "Cannot compile source file " << inputFile << ".\n"
-            << "Supported extensions are: .c, .bc, .ll\n";
+            << "Supported extensions are: .c, .i, .bc, .ll\n";
             return nullptr;
         }
 

--- a/src/LLVM/ClangFrontend.cpp
+++ b/src/LLVM/ClangFrontend.cpp
@@ -16,7 +16,6 @@
 //
 //===----------------------------------------------------------------------===//
 #include "gazer/LLVM/ClangFrontend.h"
-#include "gazer/Support/Warnings.h"
 
 #include <llvm/Support/Path.h>
 #include <llvm/Support/Program.h>

--- a/src/LLVM/ClangFrontend.cpp
+++ b/src/LLVM/ClangFrontend.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "gazer/LLVM/ClangFrontend.h"
+#include "gazer/Support/Warnings.h"
 
 #include <llvm/Support/Path.h>
 #include <llvm/Support/Program.h>
@@ -181,8 +182,11 @@ auto gazer::ClangCompileAndLink(
             bitcodeFiles.push_back(inputFile);
             continue;
         }
-
-        if (!inputFile.endswith_lower(".c")) {
+        
+        if(inputFile.endswith_lower(".i")) {
+            emit_warning("support for preprocessed .i files is an experimental feature only");
+        }
+        else if (!inputFile.endswith_lower(".c")) {
             llvm::errs() << "Cannot compile source file " << inputFile << ".\n"
             << "Supported extensions are: .c, .bc, .ll\n";
             return nullptr;

--- a/src/LLVM/ClangFrontend.cpp
+++ b/src/LLVM/ClangFrontend.cpp
@@ -183,10 +183,9 @@ auto gazer::ClangCompileAndLink(
             continue;
         }
         
-        if(inputFile.endswith_lower(".i")) {
+        if (inputFile.endswith_lower(".i")) {
             emit_warning("support for preprocessed .i files is an experimental feature only");
-        }
-        else if (!inputFile.endswith_lower(".c")) {
+        } else if (!inputFile.endswith_lower(".c")) {
             llvm::errs() << "Cannot compile source file " << inputFile << ".\n"
             << "Supported extensions are: .c, .bc, .ll\n";
             return nullptr;


### PR DESCRIPTION
Although it may be possible to run into errors if the source file is preprocessed, most of them should cause no problems at all, so with an added warning they can be enabled and require no internal changes.

This feature would be important to have for SVComp, as in some task groups .i files are used frequently. At SVComp we can support most of these as they are only used to substitute given values with #define expressions, nothing complicated. (I think these macros were used when generating the tasks from some kind of template.)