### PR TITLE
Upgrade to Theta 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - python3-setuptools
     - python3-psutil
 env:
-- THETA_VERSION="v2.1.0"
+- THETA_VERSION="v2.2.0"
 script:
 # fetch LLVM and other dependencies
 - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - python3-setuptools
     - python3-psutil
 env:
-- THETA_VERSION="v1.7.0"
+- THETA_VERSION="v2.1.0"
 script:
 # fetch LLVM and other dependencies
 - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV THETA_VERSION v1.7.0
+ENV THETA_VERSION v2.1.0
 
 RUN apt-get update && \
     apt-get install -y build-essential git cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV THETA_VERSION v2.1.0
+ENV THETA_VERSION v2.2.0
 
 RUN apt-get update && \
     apt-get install -y build-essential git cmake \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides a user-friendly end-to-end verification workflow, with support for m
 
 Currently we support two verification backends:
 * `gazer-theta` leverages the power of the [theta](https://github.com/ftsrg/theta) model checking framework.
-  * Currently, [v2.1.0](https://github.com/ftsrg/theta/releases/tag/v2.1.0) is tested, but newer releases might also work.
+  * Currently, [v2.2.0](https://github.com/ftsrg/theta/releases/tag/v2.2.0) is tested, but newer releases might also work.
 * `gazer-bmc` is gazer's built-in bounded model checking engine.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It provides a user-friendly end-to-end verification workflow, with support for m
 
 Currently we support two verification backends:
 * `gazer-theta` leverages the power of the [theta](https://github.com/ftsrg/theta) model checking framework.
-  * Currently, [v1.7.0](https://github.com/ftsrg/theta/releases/tag/v1.7.0) is tested, but newer releases might also work.
+  * Currently, [v2.1.0](https://github.com/ftsrg/theta/releases/tag/v2.1.0) is tested, but newer releases might also work.
 * `gazer-bmc` is gazer's built-in bounded model checking engine.
 
 # Usage

--- a/tools/gazer-theta/gazer-theta.cpp
+++ b/tools/gazer-theta/gazer-theta.cpp
@@ -61,6 +61,10 @@ namespace
         cl::cat(ThetaEnvironmentCategory),
         cl::init("")
     );
+    cl::opt<bool> StackTrace("stacktrace",
+        cl::desc("Get full stack trace from Theta in case of an exception"),
+        cl::cat(ThetaEnvironmentCategory)
+    );
 
     // Algorithm options
     cl::OptionCategory ThetaAlgorithmCategory("Theta algorithm settings");
@@ -169,6 +173,7 @@ theta::ThetaSettings initSettingsFromCommandLine()
 
     settings.timeout = 0; // TODO
     settings.modelPath = ModelPath;
+    settings.stackTrace = StackTrace;
     settings.domain = Domain;
     settings.refinement = Refinement;
     settings.search = Search;

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -122,6 +122,8 @@ auto ThetaVerifierImpl::execute(llvm::StringRef input) -> std::unique_ptr<Verifi
 
     std::string javaLibPath = ("-Djava.library.path=" + z3Path).str();
 
+    std::string stackTrace = mSettings.stackTrace ? "--stacktrace" : "";
+
     std::vector<llvm::StringRef> args = {
         "java",
         javaLibPath,
@@ -138,7 +140,8 @@ auto ThetaVerifierImpl::execute(llvm::StringRef input) -> std::unique_ptr<Verifi
         "--search", mSettings.search,
         "--maxenum", mSettings.maxEnum,
         "--loglevel", "RESULT",
-        "--cex", cexFile
+        "--cex", cexFile,
+        stackTrace
     };
 
     std::string ldLibPathEnv = ("LD_LIBRARY_PATH=" + z3Path).str();

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -141,8 +141,9 @@ auto ThetaVerifierImpl::execute(llvm::StringRef input) -> std::unique_ptr<Verifi
         "--cex", cexFile
     };
 
-    if (mSettings.stackTrace) args.push_back("--stacktrace");
-
+    if (mSettings.stackTrace) {
+        args.push_back("--stacktrace");
+    }
     std::string ldLibPathEnv = ("LD_LIBRARY_PATH=" + z3Path).str();
     llvm::ArrayRef<llvm::StringRef> env = {
         llvm::StringRef(ldLibPathEnv)

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -122,8 +122,6 @@ auto ThetaVerifierImpl::execute(llvm::StringRef input) -> std::unique_ptr<Verifi
 
     std::string javaLibPath = ("-Djava.library.path=" + z3Path).str();
 
-    std::string stackTrace = mSettings.stackTrace ? "--stacktrace" : "";
-
     std::vector<llvm::StringRef> args = {
         "java",
         javaLibPath,
@@ -140,9 +138,10 @@ auto ThetaVerifierImpl::execute(llvm::StringRef input) -> std::unique_ptr<Verifi
         "--search", mSettings.search,
         "--maxenum", mSettings.maxEnum,
         "--loglevel", "RESULT",
-        "--cex", cexFile,
-        stackTrace
+        "--cex", cexFile
     };
+
+    if (mSettings.stackTrace) args.push_back("--stacktrace");
 
     std::string ldLibPathEnv = ("LD_LIBRARY_PATH=" + z3Path).str();
     llvm::ArrayRef<llvm::StringRef> env = {

--- a/tools/gazer-theta/lib/ThetaVerifier.h
+++ b/tools/gazer-theta/lib/ThetaVerifier.h
@@ -31,6 +31,7 @@ struct ThetaSettings
     std::string thetaLibPath;
     unsigned timeout = 0;
     std::string modelPath;
+    bool stackTrace = false;
 
     // Algorithm settings
     std::string domain;


### PR DESCRIPTION
This PR upgrades to Theta v2.1.0. The major version change is due to the `xsts` formalism, there is not much new for `cfa`s. However, the errorreporting was improved, with a new `--stacktrace` flag that I also introduced to Gazer. This makes it easier to debug verifier exceptions.