### PR TITLE
Bitvector and array literal support for Theta backend

### DIFF
--- a/src/Automaton/RecursiveToCyclicCfa.cpp
+++ b/src/Automaton/RecursiveToCyclicCfa.cpp
@@ -42,15 +42,16 @@ public:
     RecursiveToCyclicResult transform();
 
 private:
-    void addUniqueErrorLocation();
     void inlineCallIntoRoot(CallTransition* call, llvm::Twine suffix);
+    void createErrorTransition(Location* from, ExprPtr errorFieldExpr);
+    void createDummyErrorTransition();
 
 private:
     Cfa* mRoot;
     CallGraph mCallGraph;
     llvm::SmallVector<CallTransition*, 8> mTailRecursiveCalls;
-    Location* mError;
-    Variable* mErrorFieldVariable;;
+    Location* mError = nullptr;
+    Variable* mErrorFieldVariable = nullptr;
     llvm::DenseMap<Location*, Location*> mInlinedLocations;
     llvm::DenseMap<Variable*, Variable*> mInlinedVariables;
     std::unique_ptr<ExprBuilder> mExprBuilder;
@@ -61,8 +62,16 @@ private:
 
 RecursiveToCyclicResult RecursiveToCyclicTransformer::transform()
 {
-    this->addUniqueErrorLocation();
+    mError = mRoot->createErrorLocation();
 
+    // Connect error location
+    for (Location* loc : mRoot->nodes()) {
+        if (loc->isError() && loc != mError) {
+            this->createErrorTransition(loc, mRoot->getErrorFieldExpr(loc));
+        }
+    }
+
+    // Collect tail-recursive calls
     for (Transition* edge : mRoot->edges()) {
         if (auto call = llvm::dyn_cast<CallTransition>(edge)) {
             if (mCallGraph.isTailRecursive(call->getCalledAutomaton())) {
@@ -78,6 +87,12 @@ RecursiveToCyclicResult RecursiveToCyclicTransformer::transform()
 
         this->inlineCallIntoRoot(call, "_inlined" + llvm::Twine(mInlineCnt++));
     }
+
+    if(mErrorFieldVariable == nullptr) {
+        // If there are no error locations, create one to use as goal
+        this->createDummyErrorTransition();
+    }
+
     mRoot->clearDisconnectedElements();
 
     // Calculate the new call graph and remove unneeded automata.
@@ -141,9 +156,7 @@ void RecursiveToCyclicTransformer::inlineCallIntoRoot(CallTransition* call, llvm
         locToLocMap[&*origLoc] = newLoc;
         mInlinedLocations[newLoc] = origLoc;
         if (origLoc->isError()) {
-            mRoot->createAssignTransition(newLoc, mError, mExprBuilder->True(), {
-                { mErrorFieldVariable, callee->getErrorFieldExpr(origLoc) }
-            });
+            this->createErrorTransition(newLoc, callee->getErrorFieldExpr(origLoc));
         }
     }
 
@@ -259,39 +272,33 @@ void RecursiveToCyclicTransformer::inlineCallIntoRoot(CallTransition* call, llvm
     mRoot->disconnectEdge(call);
 }
 
-void RecursiveToCyclicTransformer::addUniqueErrorLocation()
+void RecursiveToCyclicTransformer::createErrorTransition(Location *from, ExprPtr errorFieldExpr)
 {
+    assert(mError != nullptr);
+    assert(mErrorFieldVariable == nullptr || mErrorFieldVariable->getType() == errorFieldExpr->getType());
+
+    if(mErrorFieldVariable == nullptr) {
+        mErrorFieldVariable = mRoot->createLocal("__gazer_error_field", errorFieldExpr->getType());
+    }
+
+    mRoot->createAssignTransition(from, mError, BoolLiteralExpr::True(mRoot->getParent().getContext()), {
+        VariableAssignment { mErrorFieldVariable, errorFieldExpr }
+    });
+}
+
+void RecursiveToCyclicTransformer::createDummyErrorTransition()
+{
+    assert(mError != nullptr);
+    assert(mErrorFieldVariable == nullptr);
+
     auto& intTy = IntType::Get(mRoot->getParent().getContext());
     auto& ctx = mRoot->getParent().getContext();
 
-    llvm::SmallVector<Location*, 1> errors;
-    for (Location* loc : mRoot->nodes()) {
-        if (loc->isError()) {
-            errors.push_back(loc);
-        }
-    }
-    
-    mError = mRoot->createErrorLocation();
+    // A dummy error location will be used as a goal as there are no error locations in the automaton
     mErrorFieldVariable = mRoot->createLocal("__gazer_error_field", intTy);
-
-    if (errors.empty()) {
-        // If there are no error locations in the main automaton, they might still exist in a called CFA.
-        // A dummy error location will be used as a goal.
-        mRoot->createAssignTransition(mRoot->getEntry(), mError, BoolLiteralExpr::False(ctx), {
-            VariableAssignment{ mErrorFieldVariable, IntLiteralExpr::Get(intTy, 0) }
-        });        
-    } else {
-        // The error location will be directly reachable from already existing error locations.
-        for (Location* err : errors) {
-            auto errorExpr = mRoot->getErrorFieldExpr(err);
-
-            assert(errorExpr->getType().isIntType() && "Error expression must be arithmetic integers in the theta backend!");
-
-            mRoot->createAssignTransition(err, mError, BoolLiteralExpr::True(ctx), {
-                VariableAssignment { mErrorFieldVariable, errorExpr }
-            });
-        }
-    }
+    mRoot->createAssignTransition(mRoot->getEntry(), mError, BoolLiteralExpr::False(ctx), {
+        VariableAssignment{ mErrorFieldVariable, IntLiteralExpr::Get(intTy, 0) }
+    });
 }
 
 RecursiveToCyclicResult gazer::TransformRecursiveToCyclic(Cfa* cfa)

--- a/src/SolverZ3/CMakeLists.txt
+++ b/src/SolverZ3/CMakeLists.txt
@@ -4,19 +4,21 @@ set(SOURCE_FILES
 )
 
 # Z3
+
+set(Z3_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/vendor/src/z3_download/include")
+set(Z3_LIBRARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/vendor/src/z3_download/bin")
+
 ExternalProject_Add(z3_download
     PREFIX vendor
     # Download
     URL https://github.com/Z3Prover/z3/releases/download/z3-4.8.6/z3-4.8.6-x64-ubuntu-16.04.zip
     URL_HASH SHA1=1663a7825c45f24642045dfcc5e100d65c1b6b1e
+    BUILD_BYPRODUCTS "${Z3_LIBRARY_DIR}/libz3.so"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     UPDATE_COMMAND ""
     INSTALL_COMMAND ""
 )
-
-set(Z3_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/vendor/src/z3_download/include")
-set(Z3_LIBRARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/vendor/src/z3_download/bin")
 
 message("Z3 includes are ${Z3_INCLUDE_DIR}")
 

--- a/test/theta/cfa/counter.c
+++ b/test/theta/cfa/counter.c
@@ -1,4 +1,4 @@
-// RUN: %theta -model-only "%s" -o "%t"
+// RUN: %theta -model-only -math-int "%s" -o "%t"
 // RUN: cat "%t" | /usr/bin/diff -B -Z "%p/Expected/counter.theta" -
 #include <assert.h>
 

--- a/test/theta/verif/base/loops1.c
+++ b/test/theta/verif/base/loops1.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 extern int __VERIFIER_nondet_int(void);

--- a/test/theta/verif/base/loops2_fail.c
+++ b/test/theta/verif/base/loops2_fail.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification FAILED
 #include <assert.h>

--- a/test/theta/verif/base/loops3_fail.c
+++ b/test/theta/verif/base/loops3_fail.c
@@ -1,4 +1,4 @@
-// RUN: %theta -no-optimize -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -no-optimize -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification FAILED
 #include <assert.h>

--- a/test/theta/verif/base/main_no_assert.c
+++ b/test/theta/verif/base/main_no_assert.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/base/separate_assert.c
+++ b/test/theta/verif/base/separate_assert.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s"  | FileCheck "%s"
+// RUN: %theta -memory=havoc "%s" -math-int  | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/base/simple_fail.c
+++ b/test/theta/verif/base/simple_fail.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 #include <assert.h>

--- a/test/theta/verif/base/uninitialized_var_false.c
+++ b/test/theta/verif/base/uninitialized_var_false.c
@@ -1,5 +1,5 @@
-// RUN: %theta -no-optimize -memory=havoc "%s" | FileCheck "%s"
-// RUN: %theta -memory=havoc "%s"  | FileCheck "%s"
+// RUN: %theta -no-optimize -memory=havoc "%s" -math-int | FileCheck "%s"
+// RUN: %theta -memory=havoc "%s" -math-int  | FileCheck "%s"
 
 // CHECK: Verification FAILED
 

--- a/test/theta/verif/memory/arrays1.c
+++ b/test/theta/verif/memory/arrays1.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 int __VERIFIER_nondet_int(void);

--- a/test/theta/verif/memory/arrays2_fail.c
+++ b/test/theta/verif/memory/arrays2_fail.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 int __VERIFIER_nondet_int(void);

--- a/test/theta/verif/memory/globals1.c
+++ b/test/theta/verif/memory/globals1.c
@@ -1,4 +1,4 @@
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 int __VERIFIER_nondet_int(void);

--- a/test/theta/verif/memory/globals2.c
+++ b/test/theta/verif/memory/globals2.c
@@ -1,4 +1,4 @@
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 #include <limits.h>

--- a/test/theta/verif/memory/globals3.c
+++ b/test/theta/verif/memory/globals3.c
@@ -1,4 +1,4 @@
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 #include <limits.h>

--- a/test/theta/verif/memory/globals4.c
+++ b/test/theta/verif/memory/globals4.c
@@ -1,4 +1,4 @@
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/local_passbyref1_fail.c
+++ b/test/theta/verif/memory/local_passbyref1_fail.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 void __VERIFIER_error(void) __attribute__((__noreturn__));

--- a/test/theta/verif/memory/passbyref1_false.c
+++ b/test/theta/verif/memory/passbyref1_false.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 

--- a/test/theta/verif/memory/passbyref2.c
+++ b/test/theta/verif/memory/passbyref2.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/passbyref3_fail.c
+++ b/test/theta/verif/memory/passbyref3_fail.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 

--- a/test/theta/verif/memory/passbyref4.c
+++ b/test/theta/verif/memory/passbyref4.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/passbyref5.c
+++ b/test/theta/verif/memory/passbyref5.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/passbyref6.c
+++ b/test/theta/verif/memory/passbyref6.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/passbyref7_fail.c
+++ b/test/theta/verif/memory/passbyref7_fail.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.burstall
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 

--- a/test/theta/verif/memory/pointers1.c
+++ b/test/theta/verif/memory/pointers1.c
@@ -1,4 +1,4 @@
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 

--- a/test/theta/verif/memory/structs1.c
+++ b/test/theta/verif/memory/structs1.c
@@ -1,5 +1,5 @@
 // REQUIRES: memory.structs
-// RUN: %theta "%s" | FileCheck "%s"
+// RUN: %theta "%s" -math-int | FileCheck "%s"
 
 // CHECK: Verification FAILED
 

--- a/test/theta/verif/svcomp/locks/test_locks_13_true.c
+++ b/test/theta/verif/svcomp/locks/test_locks_13_true.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));

--- a/test/theta/verif/svcomp/locks/test_locks_14_false.c
+++ b/test/theta/verif/svcomp/locks/test_locks_14_false.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification FAILED
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));

--- a/test/theta/verif/svcomp/locks/test_locks_14_true.c
+++ b/test/theta/verif/svcomp/locks/test_locks_14_true.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s"  | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s"  | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));

--- a/test/theta/verif/svcomp/locks/test_locks_15_false.c
+++ b/test/theta/verif/svcomp/locks/test_locks_15_false.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification FAILED
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));

--- a/test/theta/verif/svcomp/locks/test_locks_15_true.c
+++ b/test/theta/verif/svcomp/locks/test_locks_15_true.c
@@ -1,4 +1,4 @@
-// RUN: %theta -memory=havoc "%s" | FileCheck "%s"
+// RUN: %theta -memory=havoc -math-int "%s" | FileCheck "%s"
 
 // CHECK: Verification SUCCESSFUL
 extern void __VERIFIER_error() __attribute__ ((__noreturn__));

--- a/tools/gazer-theta/CMakeLists.txt
+++ b/tools/gazer-theta/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LIB_SOURCE_FILES
+    lib/ThetaType.cpp
     lib/ThetaCfaGenerator.cpp
     lib/ThetaExpr.cpp
     lib/ThetaVerifier.cpp

--- a/tools/gazer-theta/gazer-theta.cpp
+++ b/tools/gazer-theta/gazer-theta.cpp
@@ -128,7 +128,8 @@ int main(int argc, char* argv[])
     }
 
     // Force -math-int
-    config.getSettings().ints = IntRepresentation::Integers;
+    // TODO: Find a way to make this behavior default
+    // config.getSettings().ints = IntRepresentation::Integers;
 
     // Create the frontend object
     auto frontend = config.buildFrontend(InputFilenames);

--- a/tools/gazer-theta/lib/ThetaCfaGenerator.cpp
+++ b/tools/gazer-theta/lib/ThetaCfaGenerator.cpp
@@ -45,7 +45,14 @@ constexpr std::array ThetaKeywords = {
     "return", "havoc", "bool", "int", "rat",
     "if", "then", "else", "iff", "imply",
     "forall", "exists", "or", "and", "not",
-    "mod", "rem", "true", "false"
+    "mod", "rem", "true", "false",
+    "bvadd", "bvsub", "bvpos", "bvneg",
+    "bvmul", "bvudiv", "bvsdiv",
+    "bvsmod", "bvurem", "bvsrem",
+    "bvshl", "bvashr", "bvlshr", "bvrol", "bvror",
+    "bvult", "bvule", "bvugt", "bvuge",
+    "bvslt", "bvsle", "bvsgt", "bvsge",
+    "bv_zero_extend", "bv_sign_extend"
 };
 
 struct ThetaAst

--- a/tools/gazer-theta/lib/ThetaCfaGenerator.cpp
+++ b/tools/gazer-theta/lib/ThetaCfaGenerator.cpp
@@ -16,6 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ThetaCfaGenerator.h"
+#include "ThetaType.h"
+
 #include "gazer/Core/LiteralExpr.h"
 #include "gazer/Automaton/CfaTransforms.h"
 
@@ -191,24 +193,6 @@ void ThetaEdgeDecl::print(llvm::raw_ostream& os) const
     os << "}\n";
 }
 
-static std::string typeName(Type& type)
-{
-    switch (type.getTypeID()) {
-        case Type::IntTypeID:
-            return "int";
-        case Type::RealTypeID:
-            return "rat";
-        case Type::BoolTypeID:
-            return "bool";
-        case Type::ArrayTypeID: {
-            auto& arrTy = llvm::cast<ArrayType>(type);
-            return "[" + typeName(arrTy.getIndexType()) + "] -> " + typeName(arrTy.getElementType());
-        }
-        default:
-            llvm_unreachable("Types which are unsupported by theta should have been eliminated earlier!");
-    }
-}
-
 void ThetaCfaGenerator::write(llvm::raw_ostream& os, ThetaNameMapping& nameTrace)
 {
     Cfa* main = mSystem.getMainAutomaton();
@@ -234,7 +218,7 @@ void ThetaCfaGenerator::write(llvm::raw_ostream& os, ThetaNameMapping& nameTrace
     // Add variables
     for (auto& variable : main->locals()) {
         auto name = validName(variable.getName(), isValidVarName);
-        auto type = typeName(variable.getType());
+        auto type = ThetaType::getThetaTypeName(variable.getType());
         
         nameTrace.variables[name] = &variable;
         vars.try_emplace(&variable, std::make_unique<ThetaVarDecl>(name, type));
@@ -242,7 +226,7 @@ void ThetaCfaGenerator::write(llvm::raw_ostream& os, ThetaNameMapping& nameTrace
 
     for (auto& variable : main->inputs()) {
         auto name = validName(variable.getName(), isValidVarName);
-        auto type = typeName(variable.getType());
+        auto type = ThetaType::getThetaTypeName(variable.getType());
 
         nameTrace.variables[name] = &variable;
         vars.try_emplace(&variable, std::make_unique<ThetaVarDecl>(name, type));

--- a/tools/gazer-theta/lib/ThetaExpr.cpp
+++ b/tools/gazer-theta/lib/ThetaExpr.cpp
@@ -109,7 +109,7 @@ public:
         return expr->getVariable().getName();
     }
 
-    std::string visitNot(const ExprRef<NotExpr>& expr) {
+    std::string visitNot([[maybe_unused]] const ExprRef<NotExpr>& expr) {
         return "(not " + getOperand(0) + ")";
     }
 
@@ -141,7 +141,7 @@ public:
     }
     }
 
-    std::string visitDiv(const ExprRef<DivExpr>& expr) {
+    std::string visitDiv([[maybe_unused]] const ExprRef<DivExpr>& expr) {
         return "(" + getOperand(0) + " / " + getOperand(1) + ")";
     }
 
@@ -203,7 +203,7 @@ public:
         return rso.str();
     }
 
-    std::string visitImply(const ExprRef<ImplyExpr>& expr) {
+    std::string visitImply([[maybe_unused]] const ExprRef<ImplyExpr>& expr) {
         return "(" + getOperand(0) + " imply " + getOperand(1) + ")";
     }
 
@@ -250,26 +250,28 @@ public:
     std::string visitLShr([[maybe_unused]] const ExprRef<LShrExpr>& expr) {
         return "(" + getOperand(0) + " bvlshr " + getOperand(1) + ")";
     }
+
+    std::string visitEq([[maybe_unused]] const ExprRef<EqExpr>& expr) {
         return "(" + getOperand(0) + " = " + getOperand(1) + ")";
     }
     
-    std::string visitNotEq(const ExprRef<NotEqExpr>& expr) {
+    std::string visitNotEq([[maybe_unused]] const ExprRef<NotEqExpr>& expr) {
         return "(" + getOperand(0) + " /= " + getOperand(1) + ")";
     }
 
-    std::string visitLt(const ExprRef<LtExpr>& expr) {
+    std::string visitLt([[maybe_unused]] const ExprRef<LtExpr>& expr) {
         return "(" + getOperand(0) + " < " + getOperand(1) + ")";
     }
 
-    std::string visitLtEq(const ExprRef<LtEqExpr>& expr) {
+    std::string visitLtEq([[maybe_unused]] const ExprRef<LtEqExpr>& expr) {
         return "(" + getOperand(0) + " <= " + getOperand(1) + ")";
     }
 
-    std::string visitGt(const ExprRef<GtExpr>& expr) {
+    std::string visitGt([[maybe_unused]] const ExprRef<GtExpr>& expr) {
         return "(" + getOperand(0) + " > " + getOperand(1) + ")";
     }
 
-    std::string visitGtEq(const ExprRef<GtEqExpr>& expr) {
+    std::string visitGtEq([[maybe_unused]] const ExprRef<GtEqExpr>& expr) {
         return "(" + getOperand(0) + " >= " + getOperand(1) + ")";
     }
 
@@ -304,14 +306,16 @@ public:
     std::string visitBvSGtEq([[maybe_unused]] const ExprRef<BvSGtEqExpr>& expr) {
         return "(" + getOperand(0) + " bvsge " + getOperand(1) + ")";
     }
+
+    std::string visitSelect([[maybe_unused]] const ExprRef<SelectExpr>& expr) {
         return "(if " + getOperand(0) + " then " + getOperand(1) + " else " + getOperand(2) + ")";
     }
 
-    std::string visitArrayRead(const ExprRef<ArrayReadExpr>& expr) {
+    std::string visitArrayRead([[maybe_unused]] const ExprRef<ArrayReadExpr>& expr) {
         return  "(" + getOperand(0) + ")[" + getOperand(1) + "]";
     }
 
-    std::string visitArrayWrite(const ExprRef<ArrayWriteExpr>& expr) {
+    std::string visitArrayWrite([[maybe_unused]] const ExprRef<ArrayWriteExpr>& expr) {
         return  "(" + getOperand(0) + ")[" + getOperand(1) + " <- " + getOperand(2) + "]";
     }
 

--- a/tools/gazer-theta/lib/ThetaExpr.cpp
+++ b/tools/gazer-theta/lib/ThetaExpr.cpp
@@ -71,6 +71,32 @@ public:
             auto exactString = std::bitset<sizeof (exactValue) * 8>(exactValue).to_string();
             return std::to_string(bvLit->getType().getWidth()) + "'b" + exactString.substr(exactString.length() - bvLit->getType().getWidth());
         }
+
+        if(auto arrLit = llvm::dyn_cast<ArrayLiteralExpr>(expr)) {
+            std::string arrLitStr = "[";
+
+            const auto& kvPairs = arrLit->getMap();
+            if(kvPairs.size() > 0) {
+                for(const auto& [index, elem] : kvPairs) {
+                    arrLitStr += this->walk(index) + " <- " + this->walk(elem) + ", ";
+                }
+                arrLitStr += "default <- ";
+            }
+            else {
+                arrLitStr += "<" + ThetaType::getThetaTypeName(arrLit->getType().getIndexType()) + ">default <- ";
+            }
+
+            if(arrLit->hasDefault()) {
+                arrLitStr += this->walk(arrLit->getDefault());
+            }
+            else {
+                arrLitStr += ThetaType::getThetaTypeDefaultValue(arrLit->getType().getElementType());
+            }
+
+            arrLitStr += "]";
+            return arrLitStr;
+        }
+
         return visitExpr(expr);
     }
 

--- a/tools/gazer-theta/lib/ThetaExpr.cpp
+++ b/tools/gazer-theta/lib/ThetaExpr.cpp
@@ -119,8 +119,8 @@ public:
             return "(" + getOperand(0) + " bvadd " + getOperand(1) + ")";
         }
         else {
-        return "(" + getOperand(0) + " + " + getOperand(1) + ")";
-    }
+            return "(" + getOperand(0) + " + " + getOperand(1) + ")";
+        }
     }
 
     std::string visitSub(const ExprRef<SubExpr>& expr) {
@@ -128,8 +128,8 @@ public:
             return "(" + getOperand(0) + " bvsub " + getOperand(1) + ")";
         }
         else {
-        return "(" + getOperand(0) + " - " + getOperand(1) + ")";
-    }
+            return "(" + getOperand(0) + " - " + getOperand(1) + ")";
+        }
     }
 
     std::string visitMul(const ExprRef<MulExpr>& expr) {
@@ -137,8 +137,8 @@ public:
             return "(" + getOperand(0) + " bvmul " + getOperand(1) + ")";
         }
         else {
-        return "(" + getOperand(0) + " * " + getOperand(1) + ")";
-    }
+            return "(" + getOperand(0) + " * " + getOperand(1) + ")";
+        }
     }
 
     std::string visitDiv([[maybe_unused]] const ExprRef<DivExpr>& expr) {
@@ -158,8 +158,8 @@ public:
             return "(" + getOperand(0) + " bvsmod " + getOperand(1) + ")";
         }
         else {
-        return "(" + getOperand(0) + " mod " + getOperand(1) + ")";
-    }
+            return "(" + getOperand(0) + " mod " + getOperand(1) + ")";
+        }
     }
 
     std::string visitBvURem([[maybe_unused]] const ExprRef<BvURemExpr>& expr) {

--- a/tools/gazer-theta/lib/ThetaType.cpp
+++ b/tools/gazer-theta/lib/ThetaType.cpp
@@ -1,0 +1,66 @@
+//==-------------------------------------------------------------*- C++ -*--==//
+//
+// Copyright 2019 Contributors to the Gazer project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ThetaType.h"
+
+using namespace gazer;
+using namespace gazer::theta;
+
+std::string ThetaType::getThetaTypeName(Type &type)
+{
+    switch (type.getTypeID()) {
+        case Type::IntTypeID:
+            return "int";
+        case Type::RealTypeID:
+            return "rat";
+        case Type::BoolTypeID:
+            return "bool";
+        case Type::ArrayTypeID: {
+            auto& arrTy = llvm::cast<ArrayType>(type);
+            return "[" + getThetaTypeName(arrTy.getIndexType()) + "] -> " + getThetaTypeName(arrTy.getElementType());
+        }
+        case Type::BvTypeID: {
+            auto& bvTy = llvm::cast<BvType>(type);
+            return "bv[" + std::to_string(bvTy.getWidth()) + "]";
+        }
+        default:
+            llvm_unreachable("Types which are unsupported by theta should have been eliminated earlier!");
+    }
+}
+
+std::string ThetaType::getThetaTypeDefaultValue(Type &type)
+{
+    switch (type.getTypeID()) {
+        case Type::IntTypeID:
+            return "0";
+        case Type::RealTypeID:
+            return "0%1";
+        case Type::BoolTypeID:
+            return "false";
+        case Type::ArrayTypeID: {
+            auto& arrTy = llvm::cast<ArrayType>(type);
+            return "[<" + getThetaTypeName(arrTy.getIndexType()) + ">default <- " + getThetaTypeDefaultValue(arrTy.getElementType()) + "]";
+        }
+        case Type::BvTypeID: {
+            auto& bvTy = llvm::cast<BvType>(type);
+            return std::to_string(bvTy.getWidth()) + "'d0";
+        }
+        default:
+            llvm_unreachable("Types which are unsupported by theta should have been eliminated earlier!");
+    }
+}

--- a/tools/gazer-theta/lib/ThetaType.h
+++ b/tools/gazer-theta/lib/ThetaType.h
@@ -1,0 +1,39 @@
+//==-------------------------------------------------------------*- C++ -*--==//
+//
+// Copyright 2019 Contributors to the Gazer project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#ifndef GAZER_TOOLS_GAZERTHETA_LIB_THETATYPE_H
+#define GAZER_TOOLS_GAZERTHETA_LIB_THETATYPE_H
+
+#include "gazer/Core/Type.h"
+
+#include <string>
+
+namespace gazer::theta
+{
+
+class ThetaType final
+{
+public:
+    ThetaType() = delete;
+
+    static std::string getThetaTypeName(Type& type);
+    static std::string getThetaTypeDefaultValue(Type& type);
+};
+
+} // end namespace gazer::theta
+
+#endif // GAZER_TOOLS_GAZERTHETA_LIB_THETATYPE_H

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -30,8 +30,6 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/CommandLine.h>
 
-#include <charconv>
-
 using namespace gazer;
 using namespace gazer::theta;
 
@@ -281,9 +279,8 @@ static auto parseBvLiteral(sexpr::Value* sexpr, BvType& varTy) -> boost::intrusi
         auto bvLitValueStr = std::get<1>(lit).substr(1);
 
         unsigned bvSize;
-        auto [p, ec] = std::from_chars(bvSizeStr.data(), bvSizeStr.data() + bvSizeStr.size(), bvSize);
 
-        if (ec == std::errc() && bvSize == varTy.getWidth()) {
+        if (!bvSizeStr.getAsInteger(10, bvSize) && bvSize == varTy.getWidth()) {
             switch (std::tolower(bvLitForm)) {
                 case 'b':
                     if (!bvLitValueStr.getAsInteger(2, intVal)) {

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -315,6 +315,31 @@ static auto parseBvLiteral(sexpr::Value* sexpr, BvType& varTy) -> boost::intrusi
         return nullptr;
     }
 }
+
+static auto parseArrayLiteral(sexpr::Value* sexpr, ArrayType& varTy) -> boost::intrusive_ptr<LiteralExpr>
+{
+    auto arrLitImpl = sexpr->asList();
+    // The string "array" at the beginning
+    arrLitImpl.erase(arrLitImpl.begin());
+
+    ArrayLiteralExpr::MappingT entries;
+    ExprRef<LiteralExpr> def = nullptr;
+
+    for(auto arrEntryImpl : arrLitImpl) {
+        auto keyImpl = arrEntryImpl->asList()[0];
+        auto valueImpl = arrEntryImpl->asList()[1];
+
+        if(keyImpl->isAtom() && keyImpl->asAtom() == "default") {
+            def = parseLiteral(valueImpl, varTy.getElementType());
+        }
+        else {
+            entries[parseLiteral(keyImpl, varTy.getIndexType())] = parseLiteral(valueImpl, varTy.getElementType());
+        }
+    }
+
+    return ArrayLiteralExpr::Get(varTy, entries, def);
+}
+
 static auto parseLiteral(sexpr::Value* sexpr, Type& varTy) -> boost::intrusive_ptr<LiteralExpr>
 {
     switch (varTy.getTypeID()) {
@@ -326,6 +351,9 @@ static auto parseLiteral(sexpr::Value* sexpr, Type& varTy) -> boost::intrusive_p
         }
         case Type::BvTypeID: {
             return parseBvLiteral(sexpr, cast<BvType>(varTy));
+        }
+        case Type::ArrayTypeID: {
+            return parseArrayLiteral(sexpr, cast<ArrayType>(varTy));
         }
         default: {
             return nullptr;
@@ -380,7 +408,7 @@ std::unique_ptr<Trace> ThetaVerifierImpl::parseCex(llvm::StringRef cex, unsigned
 
                 auto rhs = parseLiteral(actionList[j]->asList()[1], origVariable->getType());
                 if (rhs == nullptr) {
-                    reportInvalidCex("expected a valid integer or boolean value", cex, &*(actionList[j]->asList()[1]));
+                    reportInvalidCex("expected a valid integer, bitvector, boolean or their array as value", cex, &*(actionList[j]->asList()[1]));
                     return nullptr;
                 }
 

--- a/tools/gazer-theta/lib/ThetaVerifier.cpp
+++ b/tools/gazer-theta/lib/ThetaVerifier.cpp
@@ -30,6 +30,8 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/CommandLine.h>
 
+#include <charconv>
+
 using namespace gazer;
 using namespace gazer::theta;
 
@@ -237,6 +239,100 @@ static void reportInvalidCex(llvm::StringRef message, llvm::StringRef cex, sexpr
     llvm::errs() << "Raw counterexample is: " << cex << "\n";
 }
 
+static auto parseLiteral(sexpr::Value* sexpr, Type& varTy) -> boost::intrusive_ptr<LiteralExpr>;
+
+static auto parseBoolLiteral(sexpr::Value* sexpr, BoolType& varTy) -> boost::intrusive_ptr<LiteralExpr>
+{
+    llvm::StringRef value = sexpr->asAtom();
+    if (value.equals_lower("true")) {
+        return BoolLiteralExpr::True(varTy.getContext());
+    }
+    else if (value.equals_lower("false")) {
+        return BoolLiteralExpr::False(varTy.getContext());
+    }
+    else {
+        return nullptr;
+    }
+}
+
+static auto parseIntLiteral(sexpr::Value* sexpr, IntType& varTy) -> boost::intrusive_ptr<LiteralExpr>
+{
+    llvm::StringRef value = sexpr->asAtom();
+    long long int intVal;
+    if (!value.getAsInteger(10, intVal)) {
+        return IntLiteralExpr::Get(varTy, intVal);
+    }
+    else {
+        return nullptr;
+    }
+}
+
+static auto parseBvLiteral(sexpr::Value* sexpr, BvType& varTy) -> boost::intrusive_ptr<LiteralExpr>
+{
+    llvm::StringRef value = sexpr->asAtom();
+    llvm::APInt intVal;
+
+    if (!value.getAsInteger(10, intVal)) {
+        return BvLiteralExpr::Get(varTy, intVal.zextOrTrunc(varTy.getWidth()));
+    }
+    else if (const auto lit = value.split("'"); std::get<1>(lit) != "") {
+        auto bvSizeStr = std::get<0>(lit);
+        auto bvLitForm = std::get<1>(lit)[0];
+        auto bvLitValueStr = std::get<1>(lit).substr(1);
+
+        unsigned bvSize;
+        auto [p, ec] = std::from_chars(bvSizeStr.data(), bvSizeStr.data() + bvSizeStr.size(), bvSize);
+
+        if (ec == std::errc() && bvSize == varTy.getWidth()) {
+            switch (std::tolower(bvLitForm)) {
+                case 'b':
+                    if (!bvLitValueStr.getAsInteger(2, intVal)) {
+                        return BvLiteralExpr::Get(varTy, intVal.zextOrTrunc(varTy.getWidth()));
+                    }
+                    break;
+                case 'x':
+                    if (!bvLitValueStr.getAsInteger(16, intVal)) {
+                        return BvLiteralExpr::Get(varTy, intVal.zextOrTrunc(varTy.getWidth()));
+                    }
+                    break;
+                case 'd':
+                    if (!bvLitValueStr.getAsInteger(10, intVal)) {
+                        return BvLiteralExpr::Get(varTy, intVal.zextOrTrunc(varTy.getWidth()));
+                    }
+                    break;
+            }
+
+            // Error while parsing
+            return nullptr;
+        }
+        else {
+            // Error while parsing the size
+            return nullptr;
+        }
+    }
+    else {
+        // Not supported format
+        return nullptr;
+    }
+}
+static auto parseLiteral(sexpr::Value* sexpr, Type& varTy) -> boost::intrusive_ptr<LiteralExpr>
+{
+    switch (varTy.getTypeID()) {
+        case Type::BoolTypeID: {
+            return parseBoolLiteral(sexpr, cast<BoolType>(varTy));
+        }
+        case Type::IntTypeID: {
+            return parseIntLiteral(sexpr, cast<IntType>(varTy));
+        }
+        case Type::BvTypeID: {
+            return parseBvLiteral(sexpr, cast<BvType>(varTy));
+        }
+        default: {
+            return nullptr;
+        }
+    }
+}
+
 std::unique_ptr<Trace> ThetaVerifierImpl::parseCex(llvm::StringRef cex, unsigned* errorCode)
 {
     // TODO: The whole parsing process is very fragile. We should introduce some proper error cheks.
@@ -273,7 +369,6 @@ std::unique_ptr<Trace> ThetaVerifierImpl::parseCex(llvm::StringRef cex, unsigned
             std::vector<VariableAssignment> assigns;
             for (size_t j = 1; j < actionList.size(); ++j) {
                 llvm::StringRef varName = actionList[j]->asList()[0]->asAtom();
-                llvm::StringRef value = actionList[j]->asList()[1]->asAtom();
 
                 Variable* variable = mNameMapping.variables.lookup(varName);
                 assert(variable != nullptr && "Each variable must be present in the theta name mapping!");
@@ -283,37 +378,7 @@ std::unique_ptr<Trace> ThetaVerifierImpl::parseCex(llvm::StringRef cex, unsigned
                     origVariable = variable;
                 }
 
-                ExprPtr rhs;
-                Type& varTy = origVariable->getType();
-
-                switch (varTy.getTypeID()) {
-                    case Type::IntTypeID: {
-                        long long int intVal;
-                        if (!value.getAsInteger(10, intVal)) {
-                            rhs = IntLiteralExpr::Get(cast<IntType>(varTy), intVal);
-                        }
-                        break;
-                    }
-                    case Type::BvTypeID: {
-                        llvm::APInt intVal;
-                        if (!value.getAsInteger(10, intVal)) {
-                            auto& bvTy = cast<BvType>(varTy);
-                            rhs = BvLiteralExpr::Get(bvTy, intVal.zextOrTrunc(bvTy.getWidth()));
-                        }
-                        break;
-                    }
-                    case Type::BoolTypeID: {
-                        if (value.equals_lower("true")) {
-                            rhs = BoolLiteralExpr::True(varTy.getContext());
-                        } else if (value.equals_lower("false")) {
-                            rhs = BoolLiteralExpr::False(varTy.getContext());
-                        }
-                        break;
-                    }
-                    default:
-                        break;
-                }
-
+                auto rhs = parseLiteral(actionList[j]->asList()[1], origVariable->getType());
                 if (rhs == nullptr) {
                     reportInvalidCex("expected a valid integer or boolean value", cex, &*(actionList[j]->asList()[1]));
                     return nullptr;


### PR DESCRIPTION
This pull request adds support for bitvector expressions and array literals in the Theta backend. Also as a minor improvement closes #37 .

- [x] Bitvector support
- [x] Array literal support
- [ ] Functional tests for the new features (Depends on [this](https://github.com/ftsrg/theta/pull/77) pull request in Theta)