### PR TITLE
Fix splitCurrentTransition

### DIFF
--- a/src/LLVM/Automaton/ExtensionPoints.cpp
+++ b/src/LLVM/Automaton/ExtensionPoints.cpp
@@ -193,8 +193,11 @@ void BlocksToCfa::ExtensionPointImpl::splitCurrentTransition(const ExprPtr& guar
     Location* aux = mGenInfo.Automaton->createLocation();
 
     mGenInfo.Automaton->createAssignTransition(*mEntry, aux, mBlocksToCfa.mExprBuilder.True(), mAssigns);
-    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, guard, {});
+
+    Location* aux2 = mGenInfo.Automaton->createLocation();
+
+    mGenInfo.Automaton->createAssignTransition(aux, aux2, guard, {});
     mAssigns.clear();
 
-    *mEntry = aux;
+    *mEntry = aux2;
 }

--- a/src/LLVM/Automaton/ExtensionPoints.cpp
+++ b/src/LLVM/Automaton/ExtensionPoints.cpp
@@ -192,7 +192,8 @@ void BlocksToCfa::ExtensionPointImpl::splitCurrentTransition(const ExprPtr& guar
 {
     Location* aux = mGenInfo.Automaton->createLocation();
 
-    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, guard, mAssigns);
+    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, ExprBuilder(guard->getContext()).True(), mAssigns);
+    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, guard, {});
     mAssigns.clear();
 
     *mEntry = aux;

--- a/src/LLVM/Automaton/ExtensionPoints.cpp
+++ b/src/LLVM/Automaton/ExtensionPoints.cpp
@@ -192,7 +192,7 @@ void BlocksToCfa::ExtensionPointImpl::splitCurrentTransition(const ExprPtr& guar
 {
     Location* aux = mGenInfo.Automaton->createLocation();
 
-    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, ExprBuilder(guard->getContext()).True(), mAssigns);
+    mGenInfo.Automaton->createAssignTransition(*mEntry, aux, mBlocksToCfa.mExprBuilder.True(), mAssigns);
     mGenInfo.Automaton->createAssignTransition(*mEntry, aux, guard, {});
     mAssigns.clear();
 


### PR DESCRIPTION
Should resolve #42 . Can you check, @as3810t ?

There is a "pending list of assigns" in ExtensionPoints (mAssigns), which are cached before any control flow.

The original splitCurrentTransition moved these assigns after the just-created assume statement. (Assumes precede any assign on the same edge)