### PR TITLE
Disabling SROA: store becomes lot of extractvalues

### DIFF
--- a/src/LLVM/LLVMFrontend.cpp
+++ b/src/LLVM/LLVMFrontend.cpp
@@ -336,10 +336,10 @@ void LLVMFrontend::registerEarlyOptimizations()
     mPassManager.add(llvm::createInstructionCombiningPass());
     mPassManager.add(llvm::createCFGSimplificationPass());
 
-    // SROA may introduce new undef values, so we run another promote undef pass after it
-    mPassManager.add(llvm::createSROAPass());
-    mPassManager.add(gazer::createPromoteUndefsPass());
-    //mPassManager.add(llvm::createEarlyCSEPass());
+   // // SROA may introduce new undef values, so we run another promote undef pass after it
+   // mPassManager.add(llvm::createSROAPass());
+   // mPassManager.add(gazer::createPromoteUndefsPass());
+   // //mPassManager.add(llvm::createEarlyCSEPass());
 
     mPassManager.add(llvm::createCFGSimplificationPass());
     mPassManager.add(llvm::createAggressiveInstCombinerPass());


### PR DESCRIPTION
This is for testing out undef limitations