### PR TITLE
Patch rework build

### DIFF
--- a/src/Automaton/CMakeLists.txt
+++ b/src/Automaton/CMakeLists.txt
@@ -8,3 +8,7 @@ set(SOURCE_FILES
 
 add_library(GazerAutomaton SHARED ${SOURCE_FILES})
 target_link_libraries(GazerAutomaton GazerCore)
+
+set_target_properties(GazerAutomaton PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib"
+)

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -15,3 +15,7 @@ set(SOURCE_FILES
 
 add_library(GazerCore SHARED ${SOURCE_FILES})
 target_link_libraries(GazerCore GazerSupport)
+
+set_target_properties(GazerCore PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib"
+)

--- a/src/LLVM/CMakeLists.txt
+++ b/src/LLVM/CMakeLists.txt
@@ -35,8 +35,22 @@ set(SOURCE_FILES
     Instrumentation/Checks/DivisionByZeroCheck.cpp
     Instrumentation/Checks/SignedIntegerOverflowCheck.cpp Transform/LoopExitCanonizationPass.cpp)
 
+find_package(LLVM REQUIRED CONFIG)
+add_definitions(${LLVM_DEFINITIONS})
+include_directories(${LLVM_INCLUDE_DIRS})
+include(AddLLVM)
+
 llvm_map_components_to_libnames(GAZER_LLVM_LIBS core irreader transformutils scalaropts ipo)
 message(STATUS "Using LLVM libraries: ${GAZER_LLVM_LIBS}")
 
-add_library(GazerLLVM SHARED ${SOURCE_FILES})
-target_link_libraries(GazerLLVM ${GAZER_LLVM_LIBS} GazerCore GazerTrace GazerZ3Solver GazerAutomaton)
+add_llvm_library(GazerLLVMBase SHARED ${SOURCE_FILES})
+target_link_libraries(GazerLLVMBase GazerCore GazerTrace GazerZ3Solver GazerAutomaton)
+
+# CMake needs a file to link against for a library.
+# This is, however, unnecessary when creating a shared lib from an (LLVM) module.
+# This is a dirty workaround.
+# file(CONFIGURE TOUCH ${DESTPATH}/empty.cpp)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp CONTENT \ )
+
+add_library(GazerLLVM SHARED ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp)
+target_link_libraries(GazerLLVM GazerLLVMBase ${GAZER_LLVM_LIBS})

--- a/src/SolverZ3/CMakeLists.txt
+++ b/src/SolverZ3/CMakeLists.txt
@@ -28,3 +28,7 @@ add_dependencies(z3 z3_download)
 
 add_library(GazerZ3Solver SHARED ${SOURCE_FILES})
 target_link_libraries(GazerZ3Solver GazerCore z3)
+
+set_target_properties(GazerZ3Solver PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib"
+)

--- a/src/Support/CMakeLists.txt
+++ b/src/Support/CMakeLists.txt
@@ -6,3 +6,7 @@ llvm_map_components_to_libnames(LLVM_LIBS support)
 
 add_library(GazerSupport ${SOURCE_FILES})
 target_link_libraries(GazerSupport ${LLVM_LIBS})
+
+set_target_properties(GazerSupport PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib"
+)

--- a/src/Trace/CMakeLists.txt
+++ b/src/Trace/CMakeLists.txt
@@ -7,3 +7,7 @@ set(SOURCE_FILES
 
 add_library(GazerTrace SHARED ${SOURCE_FILES})
 target_link_libraries(GazerTrace GazerCore)
+
+set_target_properties(GazerTrace PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src/lib"
+)


### PR DESCRIPTION
This PR contains the first patch aiming to allow usage of LLVM tools (mostly `opt`) in the project.

Usage of `opt` would enable single pass tests, or later, even remove most, if not all driver (pass management) code.

It seems to me that if the build process got faster, however, it is partly because the shared libraries are not linked together (instead, the shared lib GazerLLVM.so knows all the modules used in the build process).
